### PR TITLE
Pull commits from the server and auto fix the conflict

### DIFF
--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -77,13 +77,20 @@ module.exports = function(args) {
     });
   }
 
-  function push(repo) {
+  function update(repo) {
     return git('add', '-A').then(function() {
       return git('commit', '-m', message).catch(function() {
         // Do nothing. It's OK if nothing to commit.
       });
     }).then(function() {
-      return git('push', '-u', repo.url, 'HEAD:' + repo.branch, '--force');
+      return git('pull', repo.url, repo.branch).catch(function (error) {
+        var fatal_message = error.message.split("\n")[0];
+
+        // pull from a empty repo will get this error
+        if(/fatal: Couldn't find remote ref \w/.test(fatal_message)) {}
+      });
+    }).then(function () {
+      return git('push', '-u', repo.url, 'HEAD:' + repo.branch);
     });
   }
 
@@ -122,7 +129,7 @@ module.exports = function(args) {
   }).then(function() {
     return parseConfig(args);
   }).each(function(repo) {
-    return push(repo);
+    return update(repo);
   });
 };
 

--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -86,8 +86,16 @@ module.exports = function(args) {
       return git('pull', repo.url, repo.branch).catch(function (error) {
         var fatal_message = error.message.split("\n")[0];
 
-        // pull from a empty repo will get this error
-        if(/fatal: Couldn't find remote ref \w/.test(fatal_message)) {}
+        if(/fatal: Couldn't find remote ref \w/.test(fatal_message)) {
+          // pull from a empty repo will get this error
+        } else if(/warning: no common commits/.test(fatal_message)) {
+          // conflict error
+          return git('checkout', '--ours', '.').then(function () {
+            return git('commit', '-am', 'fix conflict');
+          });
+        } else {
+          throw error;
+        }
       });
     }).then(function () {
       return git('push', '-u', repo.url, 'HEAD:' + repo.branch);


### PR DESCRIPTION
Hello, Every one.

I made some changes on `lib/deployer.js`. Now, it will pull commits from the server and push the local commits to the server.

At the same time, if conflict occurs, it will auto select the local branch and push it to the server. I also add a unit test called `auto fix the conflict` to simulate this situation.
- [ ] Make [Travis-CI](https://travis-ci.org/hexojs/hexo-deployer-git/jobs/165812885) happier (currently it failed on coding styles)
- [ ] Add a system setting for this function and default to false to avoid affect current users 
