### PR TITLE
Feature: add `ignore_pattern` in configuration

### DIFF
--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -107,9 +107,9 @@ module.exports = function(args) {
     }
 
     if (typeof ignorePattern === 'string') {
-        opts.ignorePattern = new RegExp(ignorePattern);
+      opts.ignorePattern = new RegExp(ignorePattern);
     } else if (typeof ignorePattern === 'object' && ignorePattern.hasOwnProperty('public')) {
-        opts.ignorePattern = new RegExp(ignorePattern.public);
+      opts.ignorePattern = new RegExp(ignorePattern.public);
     }
 
     return fs.copyDir(publicDir, deployDir, opts);
@@ -136,9 +136,9 @@ module.exports = function(args) {
       }
 
       if (typeof ignorePattern === 'string') {
-          opts.ignorePattern = new RegExp(ignorePattern);
+        opts.ignorePattern = new RegExp(ignorePattern);
       } else if (typeof ignorePattern === 'object' && ignorePattern.hasOwnProperty(dir)) {
-          opts.ignorePattern = new RegExp(ignorePattern[dir]);
+        opts.ignorePattern = new RegExp(ignorePattern[dir]);
       }
 
       return fs.copyDir(extendPath, extendDist, opts);

--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -21,6 +21,7 @@ module.exports = function(args) {
   var publicDir = this.public_dir;
   var extendDirs = args.extend_dirs;
   var ignoreHidden = args.ignore_hidden;
+  var ignorePattern = args.ignore_pattern;
   var log = this.log;
   var message = commitMessage(args);
   var verbose = !args.silent;
@@ -105,6 +106,12 @@ module.exports = function(args) {
       opts.ignoreHidden = ignoreHidden;
     }
 
+    if (typeof ignorePattern === 'string') {
+        opts.ignorePattern = new RegExp(ignorePattern);
+    } else if (typeof ignorePattern === 'object' && ignorePattern.hasOwnProperty('public')) {
+        opts.ignorePattern = new RegExp(ignorePattern.public);
+    }
+
     return fs.copyDir(publicDir, deployDir, opts);
   }).then(function() {
     log.info('Copying files from extend dirs...');
@@ -126,6 +133,12 @@ module.exports = function(args) {
         opts.ignoreHidden = ignoreHidden[dir];
       } else {
         opts.ignoreHidden = ignoreHidden;
+      }
+
+      if (typeof ignorePattern === 'string') {
+          opts.ignorePattern = new RegExp(ignorePattern);
+      } else if (typeof ignorePattern === 'object' && ignorePattern.hasOwnProperty(dir)) {
+          opts.ignorePattern = new RegExp(ignorePattern[dir]);
       }
 
       return fs.copyDir(extendPath, extendDist, opts);

--- a/test/deployer.js
+++ b/test/deployer.js
@@ -174,44 +174,42 @@ describe('deployer', function() {
 
   it('hidden files', function() {
       // with ignore_pattern
-      return fs.writeFile(pathFn.join(publicDir, '.hid'), 'hidden')
+      return fs.writeFile(pathFn.join(publicDir, 'hid'), 'hidden')
       .then(function() {
         return deployer({
           repo: fakeRemote,
-          ignore_pattern: '.',
+          ignore_pattern: 'hid',
           silent: true
         });
       }).then(function() {
         return validate();
       }).then(function() {
-          console.log(fs.exists(pathFn.join(validateDir, 'hid')));
         return fs.exists(pathFn.join(validateDir, 'hid'));
     }).then(function(status) {
-        console.log(status);
         status.should.eql(false);
       });
   });
 
-  // it('hidden extFiles', function () {
-  //     // with ignore_pattern
-  //     var extendDirName = pathFn.basename(extendDir);
-  //
-  //     return fs.writeFile(pathFn.join(extendDir, 'hid'), 'hidden')
-  //     .then(function() {
-  //       return deployer({
-  //         repo: fakeRemote,
-  //         extend_dirs: extendDirName,
-  //         ignore_pattern: {extend: '.'},
-  //         silent: true
-  //       });
-  //     }).then(function() {
-  //       return validate();
-  //     }).then(function() {
-  //       var extHidFile = pathFn.join(validateDir, extendDirName, 'hid');
-  //
-  //       return fs.readFile(extHidFile);
-  //     }).then(function(content) {
-  //       content.should.eql('hidden');
-  //     });
-  // });
+  it('hidden extFiles', function () {
+      // with ignore_pattern
+      var extendDirName = pathFn.basename(extendDir);
+
+      return fs.writeFile(pathFn.join(extendDir, 'hid'), 'hidden')
+      .then(function() {
+        return deployer({
+          repo: fakeRemote,
+          extend_dirs: extendDirName,
+          ignore_pattern: {extend: '.'},
+          silent: true
+        });
+      }).then(function() {
+        return validate();
+      }).then(function() {
+        var extHidFile = pathFn.join(validateDir, extendDirName, 'hid');
+
+        return fs.exists(extHidFile);
+      }).then(function(status) {
+        status.should.eql(false);
+      });
+  });
 });

--- a/test/deployer.js
+++ b/test/deployer.js
@@ -173,43 +173,43 @@ describe('deployer', function() {
   });
 
   it('hidden files', function() {
-      // with ignore_pattern
-      return fs.writeFile(pathFn.join(publicDir, 'hid'), 'hidden')
-      .then(function() {
-        return deployer({
-          repo: fakeRemote,
-          ignore_pattern: 'hid',
-          silent: true
-        });
-      }).then(function() {
-        return validate();
-      }).then(function() {
-        return fs.exists(pathFn.join(validateDir, 'hid'));
-    }).then(function(status) {
-        status.should.eql(false);
+    // with ignore_pattern
+    return fs.writeFile(pathFn.join(publicDir, 'hid'), 'hidden')
+    .then(function() {
+      return deployer({
+        repo: fakeRemote,
+        ignore_pattern: 'hid',
+        silent: true
       });
+    }).then(function() {
+      return validate();
+    }).then(function() {
+      return fs.exists(pathFn.join(validateDir, 'hid'));
+    }).then(function(status) {
+      status.should.eql(false);
+    });
   });
 
-  it('hidden extFiles', function () {
-      // with ignore_pattern
-      var extendDirName = pathFn.basename(extendDir);
+  it('hidden extFiles', function() {
+    // with ignore_pattern
+    var extendDirName = pathFn.basename(extendDir);
 
-      return fs.writeFile(pathFn.join(extendDir, 'hid'), 'hidden')
-      .then(function() {
-        return deployer({
-          repo: fakeRemote,
-          extend_dirs: extendDirName,
-          ignore_pattern: {extend: '.'},
-          silent: true
-        });
-      }).then(function() {
-        return validate();
-      }).then(function() {
-        var extHidFile = pathFn.join(validateDir, extendDirName, 'hid');
-
-        return fs.exists(extHidFile);
-      }).then(function(status) {
-        status.should.eql(false);
+    return fs.writeFile(pathFn.join(extendDir, 'hid'), 'hidden')
+    .then(function() {
+      return deployer({
+        repo: fakeRemote,
+        extend_dirs: extendDirName,
+        ignore_pattern: {extend: '.'},
+        silent: true
       });
+    }).then(function() {
+      return validate();
+    }).then(function() {
+      var extHidFile = pathFn.join(validateDir, extendDirName, 'hid');
+
+      return fs.exists(extHidFile);
+    }).then(function(status) {
+      status.should.eql(false);
+    });
   });
 });

--- a/test/deployer.js
+++ b/test/deployer.js
@@ -171,4 +171,47 @@ describe('deployer', function() {
       content.should.eql('hidden');
     });
   });
+
+  it('hidden files', function() {
+      // with ignore_pattern
+      return fs.writeFile(pathFn.join(publicDir, '.hid'), 'hidden')
+      .then(function() {
+        return deployer({
+          repo: fakeRemote,
+          ignore_pattern: '.',
+          silent: true
+        });
+      }).then(function() {
+        return validate();
+      }).then(function() {
+          console.log(fs.exists(pathFn.join(validateDir, 'hid')));
+        return fs.exists(pathFn.join(validateDir, 'hid'));
+    }).then(function(status) {
+        console.log(status);
+        status.should.eql(false);
+      });
+  });
+
+  // it('hidden extFiles', function () {
+  //     // with ignore_pattern
+  //     var extendDirName = pathFn.basename(extendDir);
+  //
+  //     return fs.writeFile(pathFn.join(extendDir, 'hid'), 'hidden')
+  //     .then(function() {
+  //       return deployer({
+  //         repo: fakeRemote,
+  //         extend_dirs: extendDirName,
+  //         ignore_pattern: {extend: '.'},
+  //         silent: true
+  //       });
+  //     }).then(function() {
+  //       return validate();
+  //     }).then(function() {
+  //       var extHidFile = pathFn.join(validateDir, extendDirName, 'hid');
+  //
+  //       return fs.readFile(extHidFile);
+  //     }).then(function(content) {
+  //       content.should.eql('hidden');
+  //     });
+  // });
 });


### PR DESCRIPTION
### FEATURE: add `ignore_pattern` in configuration

In order to push both the **generated files** and the **blog source files** only once by `hexo deploy` command. 

I suggest to add `ignore_pattern` in hexo root configuration. After that you can change your `_config.yaml` like this:

```yaml
# _config.yaml
deploy:
  - type: git
    repo: git@github.com:<username>/<username>.github.io.git
    branch: master
  - type: git
    repo: git@github.com:<username>/<username>.github.io.git
    branch: src
    extend_dirs: /
    ignore_hidden: false
    ignore_pattern:
        public: .
```

After running `hexo d`, your generated files which in `public` directory is in your master branch.At the same time, other files or directories like `themes/`, `source/`, `package.json` will deployed in your `src` branch.
