### PR TITLE
Optionally keep history

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ deploy:
   extend_dirs: [extend directory]
   ignore_hidden: false # default is true
   ignore_pattern: regexp  # whatever file that matches the regexp will be ignored when deploying
+  keep_history: true # default is false
 
 # or this:
 deploy:
@@ -54,6 +55,7 @@ deploy:
 - **branch**: Git branch to deploy the static site to
 - **message**: Commit message. The default commit message is `Site updated: {{ now('YYYY-MM-DD HH:mm:ss') }}`.
 - **name** and **email**: User info for committing the change, overrides global config. This info is independent of git login.
+- **keep_history**: When set to true, it will grab changes from the remote branch before pushing.
 - **extend_dirs**: Add some extensions directory to publish. e.g `demo`, `examples`
 - **ignore_hidden** (Boolean|Object): whether ignore hidden files to publish. the github requires the `.nojekyll` in root.
   * Boolean: for all dirs.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,6 @@ init:
 # Test against these versions of Node.js.
 environment:
   matrix:
-    - nodejs_version: "0.12"
     - nodejs_version: "4"
     - nodejs_version: "6"
 

--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -79,14 +79,18 @@ module.exports = function(args) {
     });
   }
 
-  function push(repo) {
-    return git('add', '-A').then(function() {
-      return git('commit', '-m', message).catch(function() {
-        // Do nothing. It's OK if nothing to commit.
-      });
-    }).then(function() {
-      return git('push', '-u', repo.url, 'HEAD:' + repo.branch, '--force');
+  function add() {
+    return git('add', '-A');
+  }
+
+  function commit() {
+    return git('commit', '-m', message).catch(function() {
+      // Do nothing. It's OK if nothing to commit.
     });
+  }
+
+  function push(repo) {
+    return git('push', '-u', repo.url, 'HEAD:' + repo.branch, '--force');
   }
 
   return fs.exists(deployDir).then(function(exist) {
@@ -150,7 +154,9 @@ module.exports = function(args) {
   }).then(function() {
     return parseConfig(args);
   }).each(function(repo) {
-    return push(repo);
+    return add().then(commit).then(function() {
+      return push(repo);
+    });
   });
 };
 

--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -74,9 +74,11 @@ module.exports = function(args) {
     }).then(function() {
       return userEmail && git('config', 'user.email', userEmail);
     }).then(function() {
-      return git('add', '-A');
+      return git('add', '-A')
     }).then(function() {
-      return git('commit', '-m', 'First commit');
+      if (!keepHistory) {
+        return git('commit', '-m', 'First commit');
+      }
     });
   }
 

--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -74,7 +74,7 @@ module.exports = function(args) {
     }).then(function() {
       return userEmail && git('config', 'user.email', userEmail);
     }).then(function() {
-      return git('add', '-A')
+      return git('add', '-A');
     }).then(function() {
       if (!keepHistory) {
         return git('commit', '-m', 'First commit');

--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -162,7 +162,7 @@ module.exports = function(args) {
     return add()
       .then(commit)
       .then(function() {
-        if (args.keepHistory) {
+        if (keepHistory) {
           return rebase(repo);
         }
       }).then(function() {

--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -22,6 +22,7 @@ module.exports = function(args) {
   var extendDirs = args.extend_dirs;
   var ignoreHidden = args.ignore_hidden;
   var ignorePattern = args.ignore_pattern;
+  var keepHistory = args.keep_history || false;
   var log = this.log;
   var message = commitMessage(args);
   var verbose = !args.silent;
@@ -89,6 +90,10 @@ module.exports = function(args) {
     });
   }
 
+  function rebase(repo) {
+    return git('rebase', 'origin/' + repo.branch);
+  }
+
   function push(repo) {
     return git('push', '-u', repo.url, 'HEAD:' + repo.branch, '--force');
   }
@@ -154,9 +159,15 @@ module.exports = function(args) {
   }).then(function() {
     return parseConfig(args);
   }).each(function(repo) {
-    return add().then(commit).then(function() {
-      return push(repo);
-    });
+    return add()
+      .then(commit)
+      .then(function() {
+        if (args.keepHistory) {
+          return rebase(repo);
+        }
+      }).then(function() {
+        return push(repo);
+      });
   });
 };
 

--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -91,7 +91,7 @@ module.exports = function(args) {
   }
 
   function rebase(repo) {
-    return git('rebase', 'origin/' + repo.branch);
+    return git('pull', '--rebase', repo.url, repo.branch);
   }
 
   function push(repo) {

--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -91,7 +91,10 @@ module.exports = function(args) {
   }
 
   function rebase(repo) {
-    return git('pull', '--rebase', repo.url, repo.branch);
+    return git('pull', '--rebase', repo.url, repo.branch)
+      .catch(function() {
+        // Do nothing, it's OK if we can't rebase
+      });
   }
 
   function push(repo) {

--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -91,7 +91,7 @@ module.exports = function(args) {
   }
 
   function rebase(repo) {
-    return git('pull', '--rebase', repo.url, repo.branch)
+    return git('pull', '--rebase', repo.url, repo.branch, '-s', 'recursive', '-X', 'theirs')
       .catch(function() {
         // Do nothing, it's OK if we can't rebase
       });

--- a/test/deployer.js
+++ b/test/deployer.js
@@ -250,9 +250,11 @@ describe('deployer', function() {
     function addCommit() {
       return spawn('git', ['clone', fakeRemote, otherRemote], {cwd: baseDir})
       .then(function() {
-        return spawn('git', ['commit', '--allow-empty', '-m', 'Test Commit'], {cwd: otherRemote}).catch(function(e) { console.log(e); })
+        return spawn('git', ['commit', '--allow-empty', '-m', 'Test Commit'], {cwd: otherRemote}).catch(function(e) {
+          console.log(e);
+        });
       }).then(function() {
-        return spawn('git', ['push', fakeRemote, 'HEAD:master'], {cwd: otherRemote})
+        return spawn('git', ['push', fakeRemote, 'HEAD:master'], {cwd: otherRemote});
       });
     }
 
@@ -264,7 +266,7 @@ describe('deployer', function() {
       }).then(function() {
         return validate();
       }).then(function() {
-        return spawn('git', ['log', '--skip', '1', '--pretty=format:%s'], {cwd: validateDir})
+        return spawn('git', ['log', '--skip', '1', '--pretty=format:%s'], {cwd: validateDir});
       }).then(function(logs) {
         logs.should.match(/Test Commit$/);
       });

--- a/test/deployer.js
+++ b/test/deployer.js
@@ -252,7 +252,7 @@ describe('deployer', function() {
       .then(function() {
         return spawn('git', ['commit', '--allow-empty', '-m', 'Test Commit'], {cwd: otherRemote}).catch(function(e) { console.log(e); })
       }).then(function() {
-        return spawn('git', ['push', 'origin'], {cwd: otherRemote})
+        return spawn('git', ['push', 'origin', 'master'], {cwd: otherRemote})
       });
     }
 

--- a/test/deployer.js
+++ b/test/deployer.js
@@ -252,7 +252,7 @@ describe('deployer', function() {
       .then(function() {
         return spawn('git', ['commit', '--allow-empty', '-m', 'Test Commit'], {cwd: otherRemote}).catch(function(e) { console.log(e); })
       }).then(function() {
-        return spawn('git', ['push', 'origin', 'master'], {cwd: otherRemote})
+        return spawn('git', ['push', fakeRemote, 'HEAD:master'], {cwd: otherRemote})
       });
     }
 

--- a/test/deployer.js
+++ b/test/deployer.js
@@ -244,4 +244,30 @@ describe('deployer', function() {
       });
     });
   });
+
+  it('keep history', function() {
+    var otherRemote = pathFn.join(baseDir, 'other-remote');
+    function addCommit() {
+      return spawn('git', ['clone', fakeRemote, otherRemote], {cwd: baseDir})
+      .then(function() {
+        return spawn('git', ['commit', '--allow-empty', '-m', 'Test Commit'], {cwd: otherRemote}).catch(function(e) { console.log(e); })
+      }).then(function() {
+        return spawn('git', ['push', 'origin'], {cwd: otherRemote})
+      });
+    }
+
+    return addCommit().then(function() {
+      return deployer({
+        repo: fakeRemote,
+        silent: true,
+        keep_history: true
+      }).then(function() {
+        return validate();
+      }).then(function() {
+        return spawn('git', ['log', '--skip', '1', '--pretty=format:%s'], {cwd: validateDir})
+      }).then(function(logs) {
+        logs.should.eql('Test Commit');
+      });
+    });
+  });
 });

--- a/test/deployer.js
+++ b/test/deployer.js
@@ -266,7 +266,7 @@ describe('deployer', function() {
       }).then(function() {
         return spawn('git', ['log', '--skip', '1', '--pretty=format:%s'], {cwd: validateDir})
       }).then(function(logs) {
-        logs.should.eql('Test Commit');
+        logs.should.match(/Test Commit$/);
       });
     });
   });


### PR DESCRIPTION
Adds a new option called `keep_history`. When enabled, it'll run `git pull --rebase repo.url repo.branch -s recursive -X theirs` on the repo before pushing.
The recursive theirs strategy is necessary because otherwise, particularly if we're initing a new deploy_git folder, we'd lose the new commit we just made.
I've been testing it here (https://github.com/gkatsev/blog/commits/gh-pages).

This would be instead of https://github.com/hexojs/hexo-deployer-git/pull/37 and https://github.com/hexojs/hexo-deployer-git/pull/47 and fixes https://github.com/hexojs/hexo-deployer-git/issues/33