### PR TITLE
fix(#86): fix the install command in npm@5

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,16 @@ Git deployer plugin for [Hexo].
 $ npm install hexo-deployer-git --save
 ```
 
-If you want to use the latest features of hexo-deployer-git, you may install it from github,
+If you want to use the latest features of hexo-deployer-git, you may install it from github:
+
+* for npm version under 4
 ``` bash
 $ npm install git+git@github.com:hexojs/hexo-deployer-git.git --save
+```
+
+* for npm version 5
+```bash
+$ npm install git+ssh://git@github.com:hexojs/hexo-deployer-git.git --save
 ```
 
 ## Options


### PR DESCRIPTION
fix the issue [#86](https://github.com/hexojs/hexo-deployer-git/issues/86)

the command before not support with the npm@5, in npm@5 should use a new way to install latest version of it.

![image](https://user-images.githubusercontent.com/18140164/31532655-30a72a6a-afb4-11e7-8d95-37f912a07dd9.png)
![image](https://user-images.githubusercontent.com/18140164/31532659-342fbe4a-afb4-11e7-90c6-c109256adbf8.png)
