### PR TITLE
Add an optional configuration( 'deploy.public_dir' ) for deployer

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ deploy:
   message: [message]
   name: [git user]
   email: [git email]
+  public_dir: [public directory]
   extend_dirs: [extend directory]
   ignore_hidden: false # default is true
   ignore_pattern: regexp  # whatever file that matches the regexp will be ignored when deploying
@@ -46,6 +47,7 @@ deploy:
   repo:
     github: <repository url>,[branch]
     coding: <repository url>,[branch]
+  public_dir: [public directory]
   extend_dirs:
     - [extend directory]
     - [another extend directory]
@@ -79,6 +81,7 @@ deploy:
     - type: git
       repo: git@github.com:<username>/<username>.github.io.git
       branch: src
+      public_dir: public
       extend_dirs: /
       ignore_hidden: false
       ignore_pattern:

--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -18,7 +18,7 @@ var swigHelpers = {
 module.exports = function(args) {
   var baseDir = this.base_dir;
   var deployDir = pathFn.join(baseDir, '.deploy_git');
-  var publicDir = this.public_dir;
+  var publicDir = args.public_dir || this.public_dir;
   var extendDirs = args.extend_dirs;
   var ignoreHidden = args.ignore_hidden;
   var ignorePattern = args.ignore_pattern;
@@ -40,6 +40,7 @@ module.exports = function(args) {
     help += '    repo: <repository url>\n';
     help += '    branch: [branch]\n';
     help += '    message: [message]\n\n';
+    help += '    public_dir: [public directory]\n\n';
     help += '    extend_dirs: [extend directory]\n\n';
     help += 'For more help, you can check the docs: ' + chalk.underline('http://hexo.io/docs/deployment.html');
 


### PR DESCRIPTION
Instead of using the value of "public_dir" in the main configuration file, we can specify the folder for deployment (eg: public_dir=public/blog  deploy.public_dir=public) via the value of "deploy.public_dir".
If we do not specify the value of "deploy.public_dir", the value of "public_dir" in the main configuration file will be used by default.