### PR TITLE
Update vulnerabilities dependencies

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,4 +1,0 @@
-{
-  "excludeFiles": ["node_modules/**", "coverage/**", "tmp/**"],
-  "preset": "hexo"
-}

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ before_script:
 
 script:
   - npm run eslint
-  - npm run jscs
   - npm run test-cov
 
 after_script:

--- a/lib/parse_config.js
+++ b/lib/parse_config.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var rRepoURL = /^(?:(?:git|https?|git\+https|git\+ssh):\/\/)?(?:[^@]+@)?([^\/]+?)[\/:](.+?)\.git$/;
+var rRepoURL = /^(?:(?:git|https?|git\+https|git\+ssh):\/\/)?(?:[^@]+@)?([^\/]+?)[\/:](.+?)\.git$/; // eslint-disable-line no-useless-escape
 var rGithubPage = /\.github\.(io|com)$/;
 
 function parseRepo(repo) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "index",
   "scripts": {
     "eslint": "eslint .",
-    "jscs": "jscs .",
     "test": "mocha test/index.js",
     "test-cov": "istanbul cover --print both _mocha -- test/index.js"
   },
@@ -27,12 +26,9 @@
   "license": "MIT",
   "devDependencies": {
     "chai": "^3.5.0",
-    "eslint": "^2.12.0",
-    "eslint-config-hexo": "^1.0.3",
+    "eslint": "^5.6.1",
+    "eslint-config-hexo": "^3.0.0",
     "istanbul": "^0.4.3",
-    "jscs": "^3.0.4",
-    "jscs-preset-hexo": "^1.0.1",
-    "mocha": "^2.5.3"
     "mocha": "^5.2.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "jscs": "^3.0.4",
     "jscs-preset-hexo": "^1.0.1",
     "mocha": "^2.5.3"
+    "mocha": "^5.2.0"
   },
   "dependencies": {
     "babel-eslint": "^7.2.1",

--- a/test/deployer.js
+++ b/test/deployer.js
@@ -99,21 +99,21 @@ describe('deployer', function() {
     var extendDirName = pathFn.basename(extendDir);
 
     return fs.writeFile(pathFn.join(extendDir, 'ext.txt'), 'ext')
-    .then(function() {
-      return deployer({
-        repo: fakeRemote,
-        extend_dirs: extendDirName,
-        silent: true
-      });
-    }).then(function() {
-      return validate();
-    }).then(function() {
-      var extTxtFile = pathFn.join(validateDir, extendDirName, 'ext.txt');
+      .then(function() {
+        return deployer({
+          repo: fakeRemote,
+          extend_dirs: extendDirName,
+          silent: true
+        });
+      }).then(function() {
+        return validate();
+      }).then(function() {
+        var extTxtFile = pathFn.join(validateDir, extendDirName, 'ext.txt');
 
-      return fs.readFile(extTxtFile);
-    }).then(function(content) {
-      content.should.eql('ext');
-    });
+        return fs.readFile(extTxtFile);
+      }).then(function(content) {
+        content.should.eql('ext');
+      });
   });
 
   it('multi deployment', function() {
@@ -136,41 +136,41 @@ describe('deployer', function() {
 
   it('hidden file', function() {
     return fs.writeFile(pathFn.join(publicDir, '.hid'), 'hidden')
-    .then(function() {
-      return deployer({
-        repo: fakeRemote,
-        ignore_hidden: false,
-        silent: true
+      .then(function() {
+        return deployer({
+          repo: fakeRemote,
+          ignore_hidden: false,
+          silent: true
+        });
+      }).then(function() {
+        return validate();
+      }).then(function() {
+        return fs.readFile(pathFn.join(validateDir, '.hid'));
+      }).then(function(content) {
+        content.should.eql('hidden');
       });
-    }).then(function() {
-      return validate();
-    }).then(function() {
-      return fs.readFile(pathFn.join(validateDir, '.hid'));
-    }).then(function(content) {
-      content.should.eql('hidden');
-    });
   });
 
   it('hidden extdir', function() {
     var extendDirName = pathFn.basename(extendDir);
 
     return fs.writeFile(pathFn.join(extendDir, '.hid'), 'hidden')
-    .then(function() {
-      return deployer({
-        repo: fakeRemote,
-        extend_dirs: extendDirName,
-        ignore_hidden: {public: true, extend: false},
-        silent: true
-      });
-    }).then(function() {
-      return validate();
-    }).then(function() {
-      var extHidFile = pathFn.join(validateDir, extendDirName, '.hid');
+      .then(function() {
+        return deployer({
+          repo: fakeRemote,
+          extend_dirs: extendDirName,
+          ignore_hidden: {public: true, extend: false},
+          silent: true
+        });
+      }).then(function() {
+        return validate();
+      }).then(function() {
+        var extHidFile = pathFn.join(validateDir, extendDirName, '.hid');
 
-      return fs.readFile(extHidFile);
-    }).then(function(content) {
-      content.should.eql('hidden');
-    });
+        return fs.readFile(extHidFile);
+      }).then(function(content) {
+        content.should.eql('hidden');
+      });
   });
 
   it('hidden files', function() {
@@ -182,36 +182,36 @@ describe('deployer', function() {
     var extFileShow = fs.writeFile(pathFn.join(extendDir, 'show'), 'show');
 
     return Promise.all([pubFileHid, extFileHid, extFileShow])
-    .then(function() {
-      return deployer({
-        repo: fakeRemote,
-        extend_dirs: extendDirName,
-        ignore_pattern: 'hid',
-        silent: true
+      .then(function() {
+        return deployer({
+          repo: fakeRemote,
+          extend_dirs: extendDirName,
+          ignore_pattern: 'hid',
+          silent: true
+        });
+      }).then(function() {
+        return validate();
+      }).then(function() {
+        var isPubFileHidExisits = fs.exists(pathFn.join(validateDir, 'hid'));
+        var isExtFileHidExisits = fs.exists(pathFn.join(validateDir, extendDirName, 'hid'));
+        var isExtFileShowExisits = fs.exists(pathFn.join(validateDir, extendDirName, 'show'));
+
+        return Promise.all([isPubFileHidExisits, isExtFileHidExisits, isExtFileShowExisits]);
+      }).then(function(statusLists) {
+        var pubFileHidStatus = statusLists[0];
+        var extFileHidStatus = statusLists[1];
+        var extFileShowStatus = statusLists[2];
+
+        pubFileHidStatus.should.eql(false);
+        extFileHidStatus.should.eql(false);
+        extFileShowStatus.should.eql(true);
+      }).then(function() {
+        var extShowFile = pathFn.join(validateDir, extendDirName, 'show');
+
+        return fs.readFile(extShowFile);
+      }).then(function(content) {
+        content.should.eql('show');
       });
-    }).then(function() {
-      return validate();
-    }).then(function() {
-      var isPubFileHidExisits = fs.exists(pathFn.join(validateDir, 'hid'));
-      var isExtFileHidExisits = fs.exists(pathFn.join(validateDir, extendDirName, 'hid'));
-      var isExtFileShowExisits = fs.exists(pathFn.join(validateDir, extendDirName, 'show'));
-
-      return Promise.all([isPubFileHidExisits, isExtFileHidExisits, isExtFileShowExisits]);
-    }).then(function(statusLists) {
-      var pubFileHidStatus = statusLists[0];
-      var extFileHidStatus = statusLists[1];
-      var extFileShowStatus = statusLists[2];
-
-      pubFileHidStatus.should.eql(false);
-      extFileHidStatus.should.eql(false);
-      extFileShowStatus.should.eql(true);
-    }).then(function() {
-      var extShowFile = pathFn.join(validateDir, extendDirName, 'show');
-
-      return fs.readFile(extShowFile);
-    }).then(function(content) {
-      content.should.eql('show');
-    });
   });
 
   it('hidden extFiles', function() {
@@ -223,25 +223,25 @@ describe('deployer', function() {
     var pubFileHid = fs.writeFile(pathFn.join(publicDir, 'hid'), 'hidden');
 
     return Promise.all([extFileHid, extFile2Hid, pubFileHid])
-    .then(function() {
-      return deployer({
-        repo: fakeRemote,
-        extend_dirs: extendDirName,
-        ignore_pattern: {public: 'hid', extend: '.'},
-        silent: true
-      });
-    }).then(function() {
-      return validate();
-    }).then(function() {
-      var isExtHidFileExists = fs.exists(pathFn.join(validateDir, extendDirName, 'hid'));
-      var isExtHidFile2Exists = fs.exists(pathFn.join(validateDir, extendDirName, 'hid2'));
-      var isPubHidFileExists = fs.exists(pathFn.join(validateDir, 'hid'));
+      .then(function() {
+        return deployer({
+          repo: fakeRemote,
+          extend_dirs: extendDirName,
+          ignore_pattern: {public: 'hid', extend: '.'},
+          silent: true
+        });
+      }).then(function() {
+        return validate();
+      }).then(function() {
+        var isExtHidFileExists = fs.exists(pathFn.join(validateDir, extendDirName, 'hid'));
+        var isExtHidFile2Exists = fs.exists(pathFn.join(validateDir, extendDirName, 'hid2'));
+        var isPubHidFileExists = fs.exists(pathFn.join(validateDir, 'hid'));
 
-      return Promise.all([isExtHidFileExists, isExtHidFile2Exists, isPubHidFileExists]);
-    }).then(function(statusLists) {
-      statusLists.forEach(function(statusItem) {
-        statusItem.should.eql(false);
+        return Promise.all([isExtHidFileExists, isExtHidFile2Exists, isPubHidFileExists]);
+      }).then(function(statusLists) {
+        statusLists.forEach(function(statusItem) {
+          statusItem.should.eql(false);
+        });
       });
-    });
   });
 });


### PR DESCRIPTION
### Problem

Current dependency has 6 vulnerabilities.
This problem reported from [nom install后有异常 hexo/#3215](https://github.com/hexojs/hexo/issues/3215).

Below is full report.
```
found 6 vulnerabilities (4 low, 1 high, 1 critical)
  run `npm audit fix` to fix them, or `npm audit` for details


  Low             Regular Expression Denial of Service

  Package         debug
  Dependency of   mocha [dev]
  Path            mocha > debug
  More info       https://nodesecurity.io/advisories/534

  High            Regular Expression Denial of Service

  Package         minimatch
  Dependency of   mocha [dev]
  Path            mocha > glob > minimatch
  More info       https://nodesecurity.io/advisories/118

  Critical        Command Injection

  Package         growl
  Dependency of   mocha [dev]
  Path            mocha > growl
  More info       https://nodesecurity.io/advisories/146

  Low             Prototype Pollution

  Package         lodash
  Patched in      >=4.17.5
  Dependency of   jscs [dev]
  Path            jscs > jscs-jsdoc > jsdoctypeparser > lodash
  More info       https://nodesecurity.io/advisories/577

  Low             Prototype Pollution
  Package         lodash
  Patched in      >=4.17.5
  Dependency of   jscs [dev]
  Path            jscs > lodash
  More info       https://nodesecurity.io/advisories/577

  Low             Prototype Pollution
  Package         lodash
  Patched in      >=4.17.5
  Dependency of   jscs [dev]
  Path            jscs > xmlbuilder > lodash
  More info       https://nodesecurity.io/advisories/577

found 6 vulnerabilities (4 low, 1 high, 1 critical) in 1937 scanned packages
  3 vulnerabilities require semver-major dependency updates.
  3 vulnerabilities require manual review. See the full report for details.
```

## Fix

### 1. Update dependencies 

Update dependencies package which contain vulnerabilities. Delete jscs. Current jscs has vulnerabilities and it can delete [if versionup eslint](https://www.npmjs.com/package/jscs).

### 2. Fix eslint style errors

After update eslint, code has some style error.
Fix eslint style and disable no-useless-escape of eslint rule on repository regular expression line.
About the latter a default eslint setting display no-useless-escape error, but the regular expression it seems correct. So, I ignore the line.
