### PR TITLE
Treat babel-eslint as dev dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "chai": "^4.2.0",
     "eslint": "^5.6.1",
     "eslint-config-hexo": "^3.0.0",
@@ -36,7 +37,6 @@
     "mocha": "^5.2.0"
   },
   "dependencies": {
-    "babel-eslint": "^10.0.1",
     "bluebird": "^3.5.0",
     "chalk": "^2.4.1",
     "hexo-fs": "^1.0.0",


### PR DESCRIPTION
`babel-eslint` should be a development dependency package