### PR TITLE
Read access token from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,16 @@ deploy:
   extend_dirs: [extend directory]
   ignore_hidden: false # default is true
   ignore_pattern: regexp  # whatever file that matches the regexp will be ignored when deploying
-  token: $ENV_TOKEN # read your access token from environment varable with a value starting with `$`, or hard-coded plain text
-
 # or this:
 deploy:
   type: git
   message: [message]
   repo:
     github: <repository url>,[branch]
-    coding: <repository url>,[branch]
+    coding:
+      url: <repository url>
+      branch: [branch]
+      token: [$ENV_TOKEN] # read your access token from environment varable with a value starting with `$`, or hard-coded plain text
   extend_dirs:
     - [extend directory]
     - [another extend directory]
@@ -50,6 +51,13 @@ deploy:
     [another extend directory]: false
   ignore_pattern:
     [folder]: regexp  # or you could specify the ignore_pattern under a certain directory
+
+# keys inside repo do not matter, and can be omitted for single repo with token:
+deploy:
+  repo:
+    url: <repository url>
+    token: [$ENV_TOKEN]
+  # ...your other configs
 ```
 
 - **repo**: Repository URL

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ deploy:
   extend_dirs: [extend directory]
   ignore_hidden: false # default is true
   ignore_pattern: regexp  # whatever file that matches the regexp will be ignored when deploying
+  token: $ENV_TOKEN # read your access token from environment varable with a value starting with `$`, or hard-coded plain text
 
 # or this:
 deploy:

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ deploy:
   type: git
   message: [message]
   repo:
-    coding: <repository url>[,branch]
-    github:
+  # both formats are acceptable
+    [repo host name]: <repository url>[,branch]
+    [another repo]:
       url: <repository url>
       branch: [branch]
       token: [$ENV_TOKEN]
@@ -65,7 +66,7 @@ deploy:
   - **REPO_NAME**: Name for each of your repo setting. This layer can be omitted for single repo config.
     - **url**: Url of your repositury to pull from and push to.
     - **branch**: Optional git branch to deploy the static site to.
-    - **token**: Plain text personal access token to auth push action, or a value starting with `$` to read tovalueken from environment varable. [For details](#deploy-with-token)
+    - **token**: Optional plain-text personal access token to auth push action, or a string starting with `$` to read token from environment varable. [For details](#deploy-with-token).
 - **branch**: Git branch to deploy the static site to. Would be overridden if branch in repo is configed.
 - **message**: Commit message. The default commit message is `Site updated: {{ now('YYYY-MM-DD HH:mm:ss') }}`.
 - **name** and **email**: User info for committing the change, overrides global config. This info is independent of git login.

--- a/README.md
+++ b/README.md
@@ -32,16 +32,17 @@ deploy:
   extend_dirs: [extend directory]
   ignore_hidden: false # default is true
   ignore_pattern: regexp  # whatever file that matches the regexp will be ignored when deploying
+
 # or this:
 deploy:
   type: git
   message: [message]
   repo:
-    github: <repository url>,[branch]
-    coding:
+    coding: <repository url>[,branch]
+    github:
       url: <repository url>
       branch: [branch]
-      token: [$ENV_TOKEN] # read your access token from environment varable with a value starting with `$`, or hard-coded plain text
+      token: [$ENV_TOKEN]
   extend_dirs:
     - [extend directory]
     - [another extend directory]
@@ -60,8 +61,12 @@ deploy:
   # ...your other configs
 ```
 
-- **repo**: Repository URL
-- **branch**: Git branch to deploy the static site to
+- **repo**: Repository settings, or plain url of your repo
+  - **REPO_NAME**: Name for each of your repo setting. This layer can be omitted for single repo config.
+    - **url**: Url of your repositury to pull from and push to.
+    - **branch**: Optional git branch to deploy the static site to.
+    - **token**: Plain text personal access token to auth push action, or a value starting with `$` to read tovalueken from environment varable. [For details](#deploy-with-token)
+- **branch**: Git branch to deploy the static site to. Would be overridden if branch in repo is configed.
 - **message**: Commit message. The default commit message is `Site updated: {{ now('YYYY-MM-DD HH:mm:ss') }}`.
 - **name** and **email**: User info for committing the change, overrides global config. This info is independent of git login.
 - **extend_dirs**: Add some extensions directory to publish. e.g `demo`, `examples`
@@ -87,6 +92,15 @@ deploy:
       ignore_pattern:
           public: .
   ```
+
+### Deploy with token
+
+It might be dangerous to save your account info in repo url, or a private key in deployment environment like public CI server. You can authorize the push action of deployment in `repo.token` config.
+
+- To learn more about personal access token and how to generate it, follow the guide of [creating a personal access token in Github](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line) or consult your repo host.
+- To check how to save your token in environment secretly, follow the guide of [virtual environments for GitHub Actions](https://help.github.com/articles/virtual-environments-for-github-actions#environment-variables) or consult your ci server host.
+
+> Token is **only** effective in the repo with a http(s) url.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ deploy:
   ignore_pattern:
     [folder]: regexp  # or you could specify the ignore_pattern under a certain directory
 
-# keys inside repo do not matter, and can be omitted for single repo with token:
+#names of repo do not matter, and can be omitted if there is only one repo in your config:
 deploy:
   repo:
     url: <repository url>

--- a/lib/parse_config.js
+++ b/lib/parse_config.js
@@ -1,22 +1,42 @@
 'use strict';
 
-const rRepoURL = /^(?:(?:git|https?|git\+https|git\+ssh):\/\/)?(?:[^@]+@)?([^\/]+?)[\/:](.+?)\.git$/; // eslint-disable-line no-useless-escape
+const rRepoURL = /^(?:(git|https?|git\+https|git\+ssh):\/\/)?(?:[^@]+@)?([^\/]+?)[\/:](.+?)\.git$/; // eslint-disable-line no-useless-escape
 const rGithubPage = /\.github\.(io|com)$/;
+const URL = require('url').URL;
 
-function parseRepo(repo) {
+function parseRepo(repo, configToken) {
   const split = repo.split(',');
-  const url = split.shift();
+  let url = split.shift();
   let branch = split[0];
 
   if (!branch && rRepoURL.test(url)) {
     const match = url.match(rRepoURL);
-    const host = match[1];
-    const path = match[2];
+    const scheme = match[1];
+    const host = match[2];
+    const path = match[3];
 
     if (host === 'github.com') {
       branch = rGithubPage.test(path) ? 'master' : 'gh-pages';
     } else if (host === 'coding.net') {
       branch = 'coding-pages';
+    }
+
+    if (configToken && (scheme === 'http' || scheme === 'https')) {
+      var repoUrl, userToken;
+      try {
+        repoUrl = new URL(url);
+      } catch (e) {
+        throw new TypeError('Fail to parse your repo url, check your config!');
+      }
+
+      if (configToken.startsWith('$')) {
+        userToken = process.env[configToken.substring(1)];
+        if (!userToken) throw new TypeError('Fail to read environment varable: ' + configToken + ', check your config!');
+      } else {
+        userToken = configToken;
+      }
+      repoUrl.username = userToken;
+      url = repoUrl.href;
     }
   }
 
@@ -31,14 +51,14 @@ module.exports = function(args) {
   if (!repo) throw new TypeError('repo is required!');
 
   if (typeof repo === 'string') {
-    const data = parseRepo(repo);
+    const data = parseRepo(repo, args.token);
     data.branch = args.branch || data.branch;
 
     return [data];
   }
 
   const result = Object.keys(repo).map(key => {
-    return parseRepo(repo[key]);
+    return parseRepo(repo[key], args.token);
   });
 
   return result;

--- a/lib/parse_config.js
+++ b/lib/parse_config.js
@@ -2,27 +2,22 @@
 
 const rRepoURL = /^(?:(git|https?|git\+https|git\+ssh):\/\/)?(?:[^@]+@)?([^\/]+?)[\/:](.+?)\.git$/; // eslint-disable-line no-useless-escape
 const rGithubPage = /\.github\.(io|com)$/;
-const URL = require('url').URL;
+const { URL } = require('url');
 
-function parseRepo(repo, configToken) {
-  const split = repo.split(',');
-  let url = split.shift();
-  let branch = split[0];
+function parseObjRepo(repo) {
+  let url = repo.url;
+  let branch = repo.branch;
+  let configToken = repo.token;
 
-  if (!branch && rRepoURL.test(url)) {
+  if (!branch) {
+    branch = testBranch(url);
+  }
+  if (rRepoURL.test(url)) {
     const match = url.match(rRepoURL);
     const scheme = match[1];
-    const host = match[2];
-    const path = match[3];
-
-    if (host === 'github.com') {
-      branch = rGithubPage.test(path) ? 'master' : 'gh-pages';
-    } else if (host === 'coding.net') {
-      branch = 'coding-pages';
-    }
 
     if (configToken && (scheme === 'http' || scheme === 'https')) {
-      var repoUrl, userToken;
+      let repoUrl, userToken;
       try {
         repoUrl = new URL(url);
       } catch (e) {
@@ -46,20 +41,63 @@ function parseRepo(repo, configToken) {
   };
 }
 
+function parseStrRepo(repo) {
+  const split = repo.split(',');
+  let url = split.shift();
+  let branch = split[0];
+
+  if (!branch) {
+    branch = testBranch(url);
+  }
+
+  return {
+    url: url,
+    branch: branch || 'master'
+  };
+
+}
+
+function testBranch(repoUrl) {
+  let branch;
+  if (rRepoURL.test(repoUrl)) {
+    const match = repoUrl.match(rRepoURL);
+    const host = match[2];
+    const path = match[3];
+
+    if (host === 'github.com') {
+      branch = rGithubPage.test(path) ? 'master' : 'gh-pages';
+    } else if (host === 'coding.net') {
+      branch = 'coding-pages';
+    }
+  }
+  return branch;
+}
+
 module.exports = function(args) {
   const repo = args.repo || args.repository;
   if (!repo) throw new TypeError('repo is required!');
 
   if (typeof repo === 'string') {
-    const data = parseRepo(repo, args.token);
+    const data = parseStrRepo(repo);
     data.branch = args.branch || data.branch;
 
     return [data];
   }
 
-  const result = Object.keys(repo).map(key => {
-    return parseRepo(repo[key], args.token);
+  const keys = Object.keys(repo);
+
+  if (keys.includes('url')) {
+    return [parseObjRepo(repo)];
+  }
+
+  return keys.map(key => {
+    const repoItem = repo[key];
+    if (typeof repoItem === 'string') {
+      const data = parseStrRepo(repoItem);
+      return data;
+    }
+
+    return parseObjRepo(repo[key]);
   });
 
-  return result;
 };

--- a/test/parse_config.js
+++ b/test/parse_config.js
@@ -123,35 +123,6 @@ describe('parse config', function() {
     }
   });
 
-  it('Structured single repo setting', function() {
-    parseConfig({
-      repo: {
-        url: 'https://coding.net/hexojs/hexojs.git',
-        branch: 'site'
-      }
-    })[0].branch.should.eql('site');
-  });
-
-  it('Structured multiple repo settings', function() {
-    const result = parseConfig({
-      repo: {
-        coding: {
-          url: 'https://coding.net/hexojs/hexojs.git',
-          branch: 'site',
-          token: 'plain_token'
-        },
-        github: {
-          url: 'https://github.com/hexojs/hexojs.github.io.git'
-        }
-      }
-    });
-
-    result.should.eql([
-      {url: 'https://plain_token@coding.net/hexojs/hexojs.git', branch: 'site'},
-      {url: 'https://github.com/hexojs/hexojs.github.io.git', branch: 'master'}
-    ]);
-  });
-
   it('single repo with plain text token', function() {
     // http
     parseConfig({
@@ -188,6 +159,44 @@ describe('parse config', function() {
         token: '$GIT_TOKEN'
       }
     })[0].url.should.eql('git://github.com/hexojs/hexojs.github.io.git');
+
+    delete process.env.GIT_TOKEN;
+  });
+
+  it('Structured single repo setting', function() {
+    parseConfig({
+      repo: {
+        url: 'https://coding.net/hexojs/hexojs.git',
+        branch: 'site'
+      }
+    })[0].branch.should.eql('site');
+  });
+
+  it('Structured multiple repo settings', function() {
+    process.env.GIT_TOKEN = 'env_token';
+    const result = parseConfig({
+      repo: {
+        coding: {
+          url: 'https://coding.net/hexojs/hexojs.git',
+          branch: 'site'
+        },
+        github: {
+          url: 'https://github.com/hexojs/hexojs.github.io.git',
+          token: 'plain_token'
+        },
+        other: {
+          url: 'https://example.com/path/to/repo.git',
+          token: '$GIT_TOKEN',
+          branch: 'page'
+        }
+      }
+    });
+
+    result.should.eql([
+      {url: 'https://coding.net/hexojs/hexojs.git', branch: 'site'},
+      {url: 'https://plain_token@github.com/hexojs/hexojs.github.io.git', branch: 'master'},
+      {url: 'https://env_token@example.com/path/to/repo.git', branch: 'page'}
+    ]);
 
     delete process.env.GIT_TOKEN;
   });

--- a/test/parse_config.js
+++ b/test/parse_config.js
@@ -122,4 +122,82 @@ describe('parse config', function() {
       err.should.have.property('message', 'repo is required!');
     }
   });
+
+  it('single repo with plain text token', function() {
+    // http
+    parseConfig({
+      repo: 'http://github.com/hexojs/hexojs.github.io.git',
+      token: 'plain_text_token'
+    })[0].url.should.eql('http://plain_text_token@github.com/hexojs/hexojs.github.io.git');
+
+    // https
+    parseConfig({
+      repo: 'https://github.com/hexojs/hexojs.github.io.git',
+      token: 'plain_text_token'
+    })[0].url.should.eql('https://plain_text_token@github.com/hexojs/hexojs.github.io.git');
+
+    // token config for git scheme should be ignored
+    parseConfig({
+      repo: 'git://github.com/hexojs/hexojs.github.io.git',
+      token: 'plain_text_token'
+    })[0].url.should.eql('git://github.com/hexojs/hexojs.github.io.git');
+  });
+
+  it('single repo with env var token', function() {
+    process.env.GIT_TOKEN = 'env_token';
+
+    // http
+    parseConfig({
+      repo: 'http://github.com/hexojs/hexojs.github.io.git',
+      token: '$GIT_TOKEN'
+    })[0].url.should.eql('http://env_token@github.com/hexojs/hexojs.github.io.git');
+
+    // https
+    parseConfig({
+      repo: 'https://github.com/hexojs/hexojs.github.io.git',
+      token: '$GIT_TOKEN'
+    })[0].url.should.eql('https://env_token@github.com/hexojs/hexojs.github.io.git');
+
+    // token config for git scheme should be ignored
+    parseConfig({
+      repo: 'git://github.com/hexojs/hexojs.github.io.git',
+      token: '$GIT_TOKEN'
+    })[0].url.should.eql('git://github.com/hexojs/hexojs.github.io.git');
+
+    delete process.env.GIT_TOKEN;
+  });
+
+  it('fail to read env var token', function() {
+
+    // http
+    try {
+      parseConfig({
+        repo: 'http://github.com/hexojs/hexojs.github.io.git',
+        token: '$GIT_TOKEN'
+      });
+    } catch (err) {
+      err.should.have.property('message', 'Fail to read environment varable: $GIT_TOKEN, check your config!');
+    }
+
+    // https
+    try {
+      parseConfig({
+        repo: 'https://github.com/hexojs/hexojs.github.io.git',
+        token: '$GIT_TOKEN'
+      });
+    } catch (err) {
+      err.should.have.property('message', 'Fail to read environment varable: $GIT_TOKEN, check your config!');
+    }
+  });
+
+  it('invalid url', function() {
+    try {
+      parseConfig({
+        repo: 'http:///hexojs/hexojs.github.io.git',
+        token: '$GIT_TOKEN'
+      });
+    } catch (err) {
+      err.should.have.property('message', 'Fail to parse your repo url, check your config!');
+    }
+  });
 });

--- a/test/parse_config.js
+++ b/test/parse_config.js
@@ -123,23 +123,50 @@ describe('parse config', function() {
     }
   });
 
+  it('Structured single repo setting', function() {
+    parseConfig({
+      repo: {
+        url: 'https://coding.net/hexojs/hexojs.git',
+        branch: 'site'
+      }
+    })[0].branch.should.eql('site');
+  });
+
+  it('Structured multiple repo settings', function() {
+    const result = parseConfig({
+      repo: {
+        coding: {
+          url: 'https://coding.net/hexojs/hexojs.git',
+          branch: 'site',
+          token: 'plain_token'
+        },
+        github: {
+          url: 'https://github.com/hexojs/hexojs.github.io.git'
+        }
+      }
+    });
+
+    result.should.eql([
+      {url: 'https://plain_token@coding.net/hexojs/hexojs.git', branch: 'site'},
+      {url: 'https://github.com/hexojs/hexojs.github.io.git', branch: 'master'}
+    ]);
+  });
+
   it('single repo with plain text token', function() {
     // http
     parseConfig({
-      repo: 'http://github.com/hexojs/hexojs.github.io.git',
-      token: 'plain_text_token'
+      repo: {
+        url: 'http://github.com/hexojs/hexojs.github.io.git',
+        token: 'plain_text_token'
+      }
     })[0].url.should.eql('http://plain_text_token@github.com/hexojs/hexojs.github.io.git');
-
-    // https
-    parseConfig({
-      repo: 'https://github.com/hexojs/hexojs.github.io.git',
-      token: 'plain_text_token'
-    })[0].url.should.eql('https://plain_text_token@github.com/hexojs/hexojs.github.io.git');
 
     // token config for git scheme should be ignored
     parseConfig({
-      repo: 'git://github.com/hexojs/hexojs.github.io.git',
-      token: 'plain_text_token'
+      repo: {
+        url: 'git://github.com/hexojs/hexojs.github.io.git',
+        token: 'plain_text_token'
+      }
     })[0].url.should.eql('git://github.com/hexojs/hexojs.github.io.git');
   });
 
@@ -148,20 +175,18 @@ describe('parse config', function() {
 
     // http
     parseConfig({
-      repo: 'http://github.com/hexojs/hexojs.github.io.git',
-      token: '$GIT_TOKEN'
+      repo: {
+        url: 'http://github.com/hexojs/hexojs.github.io.git',
+        token: '$GIT_TOKEN'
+      }
     })[0].url.should.eql('http://env_token@github.com/hexojs/hexojs.github.io.git');
-
-    // https
-    parseConfig({
-      repo: 'https://github.com/hexojs/hexojs.github.io.git',
-      token: '$GIT_TOKEN'
-    })[0].url.should.eql('https://env_token@github.com/hexojs/hexojs.github.io.git');
 
     // token config for git scheme should be ignored
     parseConfig({
-      repo: 'git://github.com/hexojs/hexojs.github.io.git',
-      token: '$GIT_TOKEN'
+      repo: {
+        url: 'git://github.com/hexojs/hexojs.github.io.git',
+        token: '$GIT_TOKEN'
+      }
     })[0].url.should.eql('git://github.com/hexojs/hexojs.github.io.git');
 
     delete process.env.GIT_TOKEN;
@@ -172,18 +197,10 @@ describe('parse config', function() {
     // http
     try {
       parseConfig({
-        repo: 'http://github.com/hexojs/hexojs.github.io.git',
-        token: '$GIT_TOKEN'
-      });
-    } catch (err) {
-      err.should.have.property('message', 'Fail to read environment varable: $GIT_TOKEN, check your config!');
-    }
-
-    // https
-    try {
-      parseConfig({
-        repo: 'https://github.com/hexojs/hexojs.github.io.git',
-        token: '$GIT_TOKEN'
+        repo: {
+          url: 'http://github.com/hexojs/hexojs.github.io.git',
+          token: '$GIT_TOKEN'
+        }
       });
     } catch (err) {
       err.should.have.property('message', 'Fail to read environment varable: $GIT_TOKEN, check your config!');
@@ -193,8 +210,10 @@ describe('parse config', function() {
   it('invalid url', function() {
     try {
       parseConfig({
-        repo: 'http:///hexojs/hexojs.github.io.git',
-        token: '$GIT_TOKEN'
+        repo: {
+          url: 'http:///hexojs/hexojs.github.io.git',
+          token: '$GIT_TOKEN'
+        }
       });
     } catch (err) {
       err.should.have.property('message', 'Fail to parse your repo url, check your config!');

--- a/test/parse_config.js
+++ b/test/parse_config.js
@@ -172,6 +172,25 @@ describe('parse config', function() {
     })[0].branch.should.eql('site');
   });
 
+  it('Single repo setting with name', function() {
+    parseConfig({
+      repo: {
+        my_repo: 'https://coding.net/hexojs/hexojs.git,site'
+      }
+    })[0].branch.should.eql('site');
+  });
+
+  it('Single structured repo setting with name', function() {
+    parseConfig({
+      repo: {
+        my_repo: {
+          url: 'https://coding.net/hexojs/hexojs.git',
+          branch: 'site'
+        }
+      }
+    })[0].branch.should.eql('site');
+  });
+
   it('Structured multiple repo settings', function() {
     process.env.GIT_TOKEN = 'env_token';
     const result = parseConfig({


### PR DESCRIPTION
I would like to deploy my blog page from some CI servers, but found that it's dangerous to store my account info in my hexo config file.

But some of the ci servers can securely store such info in environment variables, and github is accessible by Personal access token, so I managed to provide the token either from `args.token` field as plain-text, or a env-var, whose name is from config's `token` field with a prefix `$`.

Note that this feature is only functional only if the repo's scheme is `http` or `https`, but the test case provide a fake repo from disk. So I only add a stub test case. Do you have any idea to test this new feature?